### PR TITLE
Fix: Gemini response not displaying in Drug Information tab

### DIFF
--- a/templates/drug_info.html
+++ b/templates/drug_info.html
@@ -319,6 +319,11 @@
             background: #1d4ed8;
         }
 
+        .send-button:disabled {
+            background: #9ca3af;
+            cursor: not-allowed;
+        }
+
         .loading {
             display: inline-block;
             width: 16px;
@@ -422,7 +427,7 @@
 
             <div class="input-container">
                 <input type="text" id="userInput" placeholder="Ask about drug interactions, dosages, side effects..." autofocus>
-                <button class="send-button" onclick="sendMessage()">Send</button>
+                <button class="send-button" id="sendBtn" onclick="sendMessage()">Send</button>
             </div>
         </div>
     </div>
@@ -500,8 +505,8 @@
             }
         });
 
-        // Drug search functionality
-        function searchDrug() {
+        // Fixed Drug search functionality with real API integration
+        async function searchDrug() {
             const drugName = document.getElementById('drugSearch').value.trim();
             const searchBtn = document.getElementById('searchBtn');
             
@@ -517,36 +522,127 @@
             searchBtn.disabled = true;
             searchBtn.innerHTML = `Searching... <span class="loading"></span>`;
             
-            // Simulate API call - replace with your actual backend
-            setTimeout(() => {
-                addMessageToChat('assistant', `Here's information about ${drugName}: This is a simulated response. In your implementation, this would contain detailed drug information from your backend.`);
+            try {
+                // Make POST request to Flask backend
+                const response = await fetch('/get_drug_info', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        drug_name: drugName
+                    })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                
+                // Add the response to chat
+                addMessageToChat('assistant', data.response || data.message || 'No information available for this drug.');
+                
+            } catch (error) {
+                console.error('Error fetching drug information:', error);
+                addMessageToChat('assistant', `Sorry, I encountered an error while searching for information about ${drugName}. Please try again later.`);
+            } finally {
+                // Reset button state
                 searchBtn.disabled = false;
                 searchBtn.innerHTML = '🔍 Search';
                 document.getElementById('drugSearch').value = '';
-            }, 2000);
-        }
-
-        // Chat functionality
-        function sendMessage() {
-            const userInput = document.getElementById('userInput');
-            const message = userInput.value.trim();
-            
-            if (message) {
-                addMessageToChat('user', message);
-                userInput.value = '';
-                
-                // Simulate response - replace with actual API call
-                setTimeout(() => {
-                    addMessageToChat('assistant', `I understand you're asking about: "${message}". Let me provide you with relevant drug information.`);
-                }, 1000);
             }
         }
 
+        // Enhanced Chat functionality with backend integration
+        async function sendMessage() {
+            const userInput = document.getElementById('userInput');
+            const sendBtn = document.getElementById('sendBtn');
+            const message = userInput.value.trim();
+            
+            if (!message) return;
+            
+            addMessageToChat('user', message);
+            userInput.value = '';
+            
+            // Disable send button and show loading
+            sendBtn.disabled = true;
+            sendBtn.innerHTML = 'Sending... <span class="loading"></span>';
+            
+            // Show typing indicator
+            const typingDiv = document.createElement('div');
+            typingDiv.className = 'message assistant';
+            typingDiv.innerHTML = 'Assistant is typing... <span class="loading"></span>';
+            typingDiv.id = 'typing-indicator';
+            document.getElementById('chatbox').appendChild(typingDiv);
+            document.getElementById('chatbox').scrollTop = document.getElementById('chatbox').scrollHeight;
+            
+            try {
+                // Make POST request for general chat
+                const response = await fetch('/get_drug_info', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        drug_name: message
+                    })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                
+                // Remove typing indicator
+                const typingIndicator = document.getElementById('typing-indicator');
+                if (typingIndicator) {
+                    typingIndicator.remove();
+                }
+                
+                // Add the response
+                addMessageToChat('assistant', data.response || data.message || "I'm here to help with drug information. Please ask me about specific medications.");
+                
+            } catch (error) {
+                console.error('Error sending message:', error);
+                
+                // Remove typing indicator
+                const typingIndicator = document.getElementById('typing-indicator');
+                if (typingIndicator) {
+                    typingIndicator.remove();
+                }
+                
+                addMessageToChat('assistant', 'Sorry, I encountered an error. Please try again later.');
+            } finally {
+                // Reset send button
+                sendBtn.disabled = false;
+                sendBtn.innerHTML = 'Send';
+            }
+        }
+
+        // Enhanced addMessageToChat function to handle markdown rendering
         function addMessageToChat(sender, message) {
             const chatbox = document.getElementById('chatbox');
             const messageDiv = document.createElement('div');
             messageDiv.className = `message ${sender}`;
-            messageDiv.textContent = message;
+            
+            // If it's an assistant message and contains markdown-like content, render it properly
+            if (sender === 'assistant' && (message.includes('**') || message.includes('##') || message.includes('* ') || message.includes('\n'))) {
+                // Simple markdown rendering
+                let renderedMessage = message
+                    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') // Bold
+                    .replace(/## (.*?)(\n|$)/g, '<h3 style="margin: 0.5rem 0; color: #1f2937;">$1</h3>') // Headers
+                    .replace(/### (.*?)(\n|$)/g, '<h4 style="margin: 0.5rem 0; color: #374151;">$1</h4>') // Sub-headers
+                    .replace(/\* (.*?)(\n|$)/g, '• $1<br>') // Bullet points
+                    .replace(/\n\n/g, '<br><br>') // Double line breaks
+                    .replace(/\n/g, '<br>'); // Single line breaks
+                
+                messageDiv.innerHTML = renderedMessage;
+            } else {
+                messageDiv.textContent = message;
+            }
+            
             chatbox.appendChild(messageDiv);
             chatbox.scrollTop = chatbox.scrollHeight;
         }


### PR DESCRIPTION
This PR fixes the issue where Gemini responses were not visible in the chat section under the Drug Information tab.
Previously, Gemini responses only worked for drug search queries, but did not appear for free-text chat interactions with the assistant.

✅ Changes Made:
Fixed assistant message handling logic to ensure Gemini responses render correctly in both chat and search contexts.
Updated addMessageToChat() to support formatted and structured Gemini responses.
Improved rendering for Gemini messages using consistent message styling.
Added fallback handling for edge cases (empty or malformed responses).

🧪 **Before vs After (UI Screenshots)**
🔴 Before (Issue Reproduction):
Search Box: Displayed Gemini response correctly.
Chat Box: No proper response
![Before Screenshot](https://github.com/user-attachments/assets/50a3b2f3-da76-4b4a-bba6-29d6c04d8acc)

🟢 After (Issue Resolved):  
Chat Box: Continues to display Gemini responses as expected.

![After Screenshot](https://github.com/user-attachments/assets/4ef7f4c3-d799-425f-abe6-a3f0028ae78b)

Chat Box: Now properly renders Gemini responses with:
Drug Name
Uses
Dosage
Side Effects
Interactions

🔗 Related PR
#35 
