### PR TITLE
issue#23 Add speech to text feature for symptom checker

### DIFF
--- a/templates/symptom_checker.html
+++ b/templates/symptom_checker.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -306,6 +307,10 @@
                     id="symptoms" 
                     placeholder="e.g. sore throat, mild fever, headache..."
                 ></textarea>
+                <button id="mic-button" style="margin-top: 0.75rem; background: #2563eb; color: white; border: none; padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.9rem; cursor: pointer;">
+                    🎤 Speak
+                </button>
+
             </div>
             <button id="analyzeBtn" class="btn-checker" onclick="checkSymptoms()">
                 🔍 Analyze Symptoms
@@ -453,6 +458,52 @@
             }
         });
     </script>
+    <script>
+    const micButton = document.getElementById("mic-button");
+    const textarea = document.getElementById("symptoms");
+
+    let recognition;
+    if ("webkitSpeechRecognition" in window || "SpeechRecognition" in window) {
+        const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+        recognition = new SpeechRecognition();
+        recognition.lang = "en-US";
+        recognition.continuous = false;
+        recognition.interimResults = false;
+
+        recognition.onstart = function () {
+            micButton.innerText = "🎙️ Listening...";
+            micButton.disabled = true;
+        };
+
+        recognition.onend = function () {
+            micButton.innerText = "🎤 Speak";
+            micButton.disabled = false;
+        };
+
+        recognition.onresult = function (event) {
+            const transcript = event.results[0][0].transcript;
+            if (textarea.value.trim()) {
+                textarea.value += ", " + transcript;
+            } else {
+                textarea.value = transcript;
+            }
+            textarea.focus();
+        };
+
+        recognition.onerror = function (event) {
+            console.error("Speech recognition error:", event.error);
+            micButton.innerText = "🎤 Speak";
+            micButton.disabled = false;
+        };
+
+        micButton.addEventListener("click", () => {
+            recognition.start();
+        });
+    } else {
+        micButton.disabled = true;
+        micButton.innerText = "🎤 Not Supported";
+    }
+  </script>
+
 </body>
 </html>
-


### PR DESCRIPTION
📌 What does this PR do?
Added voice input functionality to the symptom checker page (symptom_checker.html) using the Web Speech API.
This allows users to speak symptoms directly into the input field.

Related Issue
Fixes https://github.com/MAVERICK-VF142/Drx.MediMate/issues/23
🔧 Type of Change
✅ New feature

✅ How Has This Been Tested?

Manually tested on both Microsoft Edge and Google Chrome.
Confirmed that speech input fills the symptom field correctly.
Tested UI rendering and form submission after speech input.
Backend worked as expected after setting the required environment variables.
📋 Environment:

OS: Windows 10
Browsers: Chrome (latest), Edge
Python app started using python app.py only after setting Google credentials via $env:GEMINI="..."

📊 Impact / Performance
No external library added. Used Web Speech API (native in modern browsers).
No observable performance overhead introduced.

✅ Checklist

 I have followed the code style guidelines.
 I have self-reviewed my code.
 I have commented on complex parts of the code.
 All tests pass locally.
 No new warnings have been introduced.