### PR TITLE
🔁 Added caching for drug info using TTLCache to reduce Gemini API calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ from flask_cors import CORS
 from PIL import Image
 from io import BytesIO
 import google.generativeai as genai
+from utils.cache import get_cached_drug, set_cached_drug
+from dotenv import load_dotenv
+load_dotenv()
 import markdown
 import logging
 import time
@@ -114,12 +117,20 @@ def get_drug_information(drug_name):
     )
 
     logging.info(f"Prompt to Gemini: {prompt}")
+
+    cached = get_cached_drug(drug_name)
+    if cached:
+        logging.info(f"📦 Cache hit for drug: {drug_name}")
+        return cached
+
     try:
         response = gemini_generate_with_retry(prompt)
         if response and hasattr(response, 'text'):
             text = response.text.strip()
-            logging.info("Received response from Gemini AI.")
-            return format_markdown_response(text)
+            formatted = format_markdown_response(text)
+            set_cached_drug(drug_name, formatted)
+            logging.info("✅ Cached new drug info response.")
+            return formatted
         else:
             logging.warning("No text in AI response.")
             return "❌ No response from AI."

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-cors
 Pillow
 google-generativeai
 markdown
+cachetools

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,18 @@
+from cachetools import TTLCache
+import threading
+
+# A cache with maxsize 100 items, and TTL of 600 seconds (10 minutes)
+drug_cache = TTLCache(maxsize=100, ttl=600)
+
+# Lock to prevent race conditions in threaded environments (e.g., Flask)
+cache_lock = threading.Lock()
+
+def get_cached_drug(drug_name):
+    key = drug_name.strip().lower()
+    with cache_lock:
+        return drug_cache.get(key)
+
+def set_cached_drug(drug_name, response):
+    key = drug_name.strip().lower()
+    with cache_lock:
+        drug_cache[key] = response


### PR DESCRIPTION
### 🔁 Feature: Caching Layer for Drug Info Queries

#### 📌 Description
This PR adds a caching mechanism using `cachetools.TTLCache` to optimize repeated drug information queries. When the same drug is queried more than once within a 10-minute window, the app serves the cached response instead of making another call to the Gemini API.

#### ✅ What’s Included
- ✅ Added `utils/cache.py` with TTL-based in-memory cache (10-minute expiry).
- ✅ Modified `get_drug_information()` in `app.py` to check the cache before querying Gemini.
- ✅ Logged cache hits and sets for observability.

#### ⚙️ Additional Technologies Used:
- `cachetools.TTLCache`

#### 🧪 How to Test

You can use `curl` or Postman to test the caching behavior:

###**Step 1: First request (cache miss, calls Gemini)**

```bash
curl -X POST http://localhost:5000/get_drug_info \
  -H "Content-Type: application/json" \
  -d '{"drug_name": "Paracetamol"}'
```
📝 Expected: Logs show Gemini API Call Attempt 1 and ✅ Cached new drug info response.

### Output :

<img width="1336" height="921" alt="image" src="https://github.com/user-attachments/assets/09dd8292-3e9a-423f-a0de-c8a432ba4924" />

<img width="1600" height="803" alt="image" src="https://github.com/user-attachments/assets/e93b0aa7-8ece-414f-be10-485d42757e8b" />


Step 2: Second request (cache hit, no Gemini call)
```
curl -X POST http://localhost:5000/get_drug_info \
  -H "Content-Type: application/json" \
  -d '{"drug_name": "Paracetamol"}'
```
### Output :

<img width="1600" height="837" alt="image" src="https://github.com/user-attachments/assets/6b7829de-69a1-4d4f-95d2-215b01273372" />


### 📝 Expected: Logs show 📦 Cache hit for drug: Paracetamol and returns instantly.

Wait 10+ minutes and test again to confirm cache expiry and re-fetch behavior.

📈 Benefits:

⚡ Faster response time for users.

💰 Reduces redundant Gemini API calls, saving quota and cost.

📊 Scales better under high request volume.

###🏷️ Tags

`enhancement` `performance` `backend` `cache`

---